### PR TITLE
fix: unused assert when allocing page with fsm

### DIFF
--- a/src/index/build.rs
+++ b/src/index/build.rs
@@ -143,7 +143,7 @@ unsafe fn write_down(state: &BuildState) {
     }
     let delete_bitmap_blkno = delete_bitmap_writer.finalize();
 
-    // term info
+    // term stat
     let mut term_stat_writer = PageWriter::new(state.index, PageFlags::TERM_STATISTIC, true);
     for count in state.builder.term_stat() {
         term_stat_writer.write(&count.to_le_bytes());

--- a/src/page/writer.rs
+++ b/src/page/writer.rs
@@ -26,12 +26,6 @@ impl PageWriterInitFork {
     fn change_page(&mut self) {
         let mut old_page = self.page.take().unwrap();
         let new_page = page_alloc_init_forknum(self.relation, self.flag);
-        assert!(
-            old_page.blkno() + 1 == new_page.blkno(),
-            "old: {}, new: {}",
-            old_page.blkno(),
-            new_page.blkno()
-        );
         old_page.opaque.next_blkno = new_page.blkno();
         self.page = Some(new_page);
     }
@@ -112,12 +106,6 @@ impl PageWriter {
     fn change_page(&mut self) {
         let mut old_page = self.page.take().unwrap();
         let new_page = page_alloc_with_fsm(self.relation, self.flag, self.skip_lock_rel);
-        assert!(
-            old_page.blkno() + 1 == new_page.blkno(),
-            "old: {}, new: {}",
-            old_page.blkno(),
-            new_page.blkno()
-        );
         old_page.opaque.next_blkno = new_page.blkno();
         self.page = Some(new_page);
     }


### PR DESCRIPTION
fix #14 

Previously we don't use fsm, so we can assert the allocated page number is continous. Now we have updated to use fsm and virtual pages, so these assertions are not needed.