### PR TITLE
feat: support brute-force search over all the candidates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ tantivy-stemmers = { version = "0.4.0", features = [
 thiserror = "2"
 tokenizers = { version = "0.20", default-features = false, features = ["onig"] }
 
+generator = "0.8.4"
+lending-iterator = "0.1.7"
 serde = { version = "1.0.217", features = ["derive"] }
 tocken = "0.1.0"
 toml = "0.8.19"

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ For more information about tokenizer, check the [tokenizer](./tokenizer.md) docu
 
 ### GUCs
 
-- `bm25_catalog.bm25_limit (integer)`: The maximum number of documents to return in a search. Default is 1, minimum is 1, and maximum is 65535.
+- `bm25_catalog.bm25_limit (integer)`: The maximum number of documents to return in a search. Default is 100, minimum is -1, and maximum is 65535. When set to -1, it will perform brute force search and return all documents with scores greater than 0.
 - `bm25_catalog.enable_index (boolean)`: Whether to enable the bm25 index. Default is false.
 - `bm25_catalog.segment_growing_max_page_size (integer)`: The maximum page count of the growing segment. When the size of the growing segment exceeds this value, the segment will be sealed into a read-only segment. Default is 1, minimum is 1, and maximum is 1,000,000.
 

--- a/src/guc.rs
+++ b/src/guc.rs
@@ -10,7 +10,7 @@ pub unsafe fn init() {
         "bm25 query limit",
         "The maximum number of documents to return in a search",
         &BM25_LIMIT,
-        1,
+        -1,
         65535,
         GucContext::Userset,
         GucFlags::default(),

--- a/src/index/insert.rs
+++ b/src/index/insert.rs
@@ -1,3 +1,4 @@
+use lending_iterator::LendingIterator;
 use pgrx::{itemptr::item_pointer_to_u64, FromDatum};
 
 use crate::{
@@ -95,7 +96,9 @@ pub unsafe extern "C" fn aminsert(
         }
 
         let mut writer = InvertedWriter::new();
-        let mut iter = growing_reader.into_iter(block_count);
+        let mut iter = growing_reader
+            .into_lending_iter()
+            .take(block_count as usize);
         while let Some(vector) = iter.next() {
             writer.insert(doc_id, vector);
             doc_id += 1;

--- a/src/index/vacuum.rs
+++ b/src/index/vacuum.rs
@@ -1,3 +1,5 @@
+use lending_iterator::LendingIterator;
+
 use crate::{
     page::{bm25_page_size, page_read, page_write, METAPAGE_BLKNO},
     segment::{
@@ -92,7 +94,7 @@ pub unsafe extern "C" fn amvacuumcleanup(
     if let Some(growing) = meta.growing_segment.as_ref() {
         let reader = GrowingSegmentReader::new(index, growing);
         let mut doc_id = meta.sealed_doc_id;
-        let mut iter = reader.into_iter(u32::MAX);
+        let mut iter = reader.into_lending_iter();
         while let Some(vector) = iter.next() {
             if !delete_bitmap_reader.is_delete(doc_id) {
                 for &idx in vector.indexes() {

--- a/src/utils/loser_tree.rs
+++ b/src/utils/loser_tree.rs
@@ -1,0 +1,138 @@
+use std::cmp::Reverse;
+
+pub struct LoserTree<I, T> {
+    // 0..n
+    iterators: Vec<I>,
+    // 0..m
+    x: Vec<Option<Reverse<T>>>,
+    // 0..m, m = (winner: 1) + (losers: 2 ^ 0 + 2 ^ 1 + 2 ^ 2 + 2 ^ 3 + ... + 2 ^ (k - 1))
+    losers: Vec<usize>,
+}
+
+impl<I> LoserTree<I, I::Item>
+where
+    I: Iterator,
+    I::Item: Ord,
+{
+    pub fn new(mut iterators: Vec<I>) -> Self {
+        let n = iterators.len();
+        let m = n.next_power_of_two();
+        let mut x = Vec::new();
+        x.resize_with(m, || None);
+        let mut losers = vec![usize::MAX; m];
+        for i in 0..n {
+            x[i] = iterators[i].next().map(Reverse);
+        }
+        let mut winners = vec![usize::MAX; 2 * m];
+        for i in 0..m {
+            winners[m + i] = i;
+        }
+        for i in (1..m).rev() {
+            let (l, r) = (winners[i << 1], winners[i << 1 | 1]);
+            (losers[i], winners[i]) = if x[l] < x[r] { (l, r) } else { (r, l) };
+        }
+        losers[0] = winners[1];
+        Self {
+            iterators,
+            x,
+            losers,
+        }
+    }
+}
+
+impl<I> Iterator for LoserTree<I, I::Item>
+where
+    I: Iterator,
+    I::Item: Ord,
+{
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let n = self.iterators.len();
+        let m = n.next_power_of_two();
+        let r = self.losers[0];
+        let Reverse(result) = self.x[r].take()?;
+        self.x[r] = self.iterators[r].next().map(Reverse);
+        let mut v = r;
+        let mut i = (m + r) >> 1;
+        while i != 0 {
+            if self.x[v] < self.x[self.losers[i]] {
+                std::mem::swap(&mut v, &mut self.losers[i]);
+            }
+            i >>= 1;
+        }
+        self.losers[0] = v;
+        Some(result)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rand::Rng;
+
+    fn check(seqs: &[Vec<u32>]) {
+        let brute_force = {
+            let mut result = Vec::new();
+            let mut seqs = seqs
+                .iter()
+                .map(|x| x.clone().into_iter().peekable())
+                .collect::<Vec<_>>();
+            while !seqs.is_empty() {
+                let mut index = 0usize;
+                let mut value = u32::MAX;
+                for (i, seq) in seqs.iter_mut().enumerate() {
+                    if let Some(&x) = seq.peek() {
+                        if x <= value {
+                            index = i;
+                            value = x;
+                        }
+                    }
+                }
+                let Some(_) = seqs[index].next() else { break };
+                result.push(value);
+            }
+            result
+        };
+        let loser_tree = {
+            let iterators = seqs.iter().map(|x| x.iter().copied()).collect();
+            LoserTree::new(iterators).collect::<Vec<_>>()
+        };
+        assert_eq!(brute_force, loser_tree);
+    }
+
+    #[test]
+    fn test_hardcode() {
+        check(&[]);
+        check(&[vec![0, 2, 4], vec![1, 3, 5], vec![], vec![], vec![]]);
+        check(&[vec![], vec![], vec![], vec![], vec![]]);
+        check(&[vec![1, 1, 1, 1, 1, 1]]);
+        check(&[vec![1, 2, 3, 4, 5, 6], vec![1, 2, 3, 4, 5, 6]]);
+        check(&[vec![2, 2, 3, 3, 4, 4, 5], vec![1, 1, 5, 6, 6]]);
+    }
+
+    #[test]
+    fn test_random() {
+        fn vec(n: usize) -> Vec<u32> {
+            let mut vec = vec![0u32; n];
+            vec.fill_with(|| rand::thread_rng().gen_range(0..100_000));
+            vec.sort();
+            vec
+        }
+
+        fn vecs() -> Vec<Vec<u32>> {
+            use rand::Rng;
+            let m = rand::thread_rng().gen_range(0..100);
+            let mut vecs = Vec::new();
+            for _ in 0..m {
+                let n = rand::thread_rng().gen_range(0..10000);
+                vecs.push(vec(n));
+            }
+            vecs
+        }
+
+        for _ in 0..10 {
+            check(&vecs());
+        }
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod cells;
 pub mod compress_block;
+pub mod loser_tree;
 pub mod topk_computer;
 pub mod vint;

--- a/tests/sqllogictest/brute_force.slt
+++ b/tests/sqllogictest/brute_force.slt
@@ -1,0 +1,52 @@
+statement ok
+CREATE TABLE documents (
+    id SERIAL PRIMARY KEY,
+    passage TEXT
+);
+
+statement ok
+INSERT INTO documents (passage) VALUES 
+('PostgreSQL is a powerful, open-source object-relational database system. It has over 15 years of active development.'),
+('Full-text search is a technique for searching in plain-text documents or textual database fields. PostgreSQL supports this with tsvector.'),
+('BM25 is a ranking function used by search engines to estimate the relevance of documents to a given search query.'),
+('PostgreSQL provides many advanced features like full-text search, window functions, and more.'),
+('Search and ranking in databases are important in building effective information retrieval systems.'),
+('The BM25 ranking algorithm is derived from the probabilistic retrieval framework.'),
+('Full-text search indexes documents to allow fast text queries. PostgreSQL supports this through its GIN and GiST indexes.'),
+('The PostgreSQL community is active and regularly improves the database system.'),
+('Relational databases such as PostgreSQL can handle both structured and unstructured data.'),
+('Effective search ranking algorithms, such as BM25, improve search results by understanding relevance.');
+
+statement ok
+ALTER TABLE documents ADD COLUMN embedding bm25vector;
+
+statement ok
+UPDATE documents SET embedding = tokenize(passage, 'Bert');
+
+statement ok
+CREATE INDEX documents_embedding_bm25 ON documents USING bm25 (embedding bm25_ops);
+
+statement ok
+SET enable_seqscan=off;
+
+statement ok
+SET bm25_catalog.bm25_limit = 0;
+
+query I
+SELECT id, passage, embedding <&> to_bm25query('documents_embedding_bm25', 'Post', 'Bert') AS rank
+FROM documents
+ORDER BY rank
+LIMIT 10;
+----
+
+statement ok
+SET bm25_catalog.bm25_limit = -1;
+
+statement ok
+SELECT id, passage, embedding <&> to_bm25query('documents_embedding_bm25', 'Post', 'Bert') AS rank
+FROM documents
+ORDER BY rank
+LIMIT 10;
+
+statement ok
+DROP TABLE documents;


### PR DESCRIPTION
close #26

## Implementation Details

It'll perform k-way merge for all posting lists containing query tokens. When there are muiltiple posting lists iterating the same docid, it will add all scores and push it into candidates. Finally, it will sort candidates.