### PR TITLE
refactor: change unicode tokenizer logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,28 +20,29 @@ pg17 = ["pgrx/pg17"]
 
 [dependencies]
 arrayvec = "0.7.6"
+bincode = "1.3.3"
 bitflags = "2.6.0"
 bitpacking = { version = "0.9", default-features = false, features = [
     "bitpacker4x",
 ] }
 bytemuck = "1.18"
+generator = "0.8.4"
 lazy_static = "1.5"
+lending-iterator = "0.1.7"
 pgrx = { version = "=0.12.8", default-features = false, features = ["cshim"] }
 regex = "1.11.1"
+rust-stemmers = { git = "https://github.com/silver-ymz/rust-stemmers.git" }
+serde = { version = "1.0.217", features = ["derive"] }
 stop-words = "0.8.0"
 tantivy-stemmers = { version = "0.4.0", features = [
     "default",
     "english_porter",
 ] }
 thiserror = "2"
-tokenizers = { version = "0.20", default-features = false, features = ["onig"] }
-
-bincode = "1.3.3"
-generator = "0.8.4"
-lending-iterator = "0.1.7"
-serde = { version = "1.0.217", features = ["derive"] }
 tocken = "0.1.0"
+tokenizers = { version = "0.20", default-features = false, features = ["onig"] }
 toml = "0.8.19"
+unicode-normalization = "0.1.24"
 unicode-segmentation = "1.12.0"
 validator = { version = "0.19.0", features = ["derive"] }
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -145,7 +145,7 @@ struct TokenizerConfig {
 
 impl TokenizerConfig {
     fn default_stopwords() -> StopWordsKind {
-        StopWordsKind::LucenePlusNltk
+        StopWordsKind::Nltk
     }
 
     fn validate_unicode(&self) -> Result<(), ValidationError> {


### PR DESCRIPTION
## bench

- dataset: trec-covid
- machine: 4 vCPU, 6 GB, Apple M1, lxc Virtualization

NDCG@10:
- VectorChord-bm25 + nltk stopwords: **0.67253**
- VectorChord-bm25 + nltk_and_lucene stopwords: **0.67253** (prev: 0.64832)
- VectorChord-bm25 + lucene stopwords: **0.60986** (prev: 0.60726)
- elastic-search: **0.68803**
