### PR TITLE
refactor: optimize block_wand

### DIFF
--- a/src/algorithm/block_wand.rs
+++ b/src/algorithm/block_wand.rs
@@ -202,12 +202,16 @@ fn block_max_was_too_low_advance_one_scorer(
 
 fn restore_ordering(indexes: &mut [(u32, u32)], ord: usize) {
     let doc = indexes[ord].1;
-    for i in ord + 1..indexes.len() {
-        if indexes[i].1 >= doc {
-            break;
-        }
-        indexes.swap(i, i - 1);
-    }
+    let pos = match indexes[(ord + 1)..]
+        .iter()
+        .position(|(_, docid)| *docid >= doc)
+    {
+        Some(pos) => pos,
+        None => indexes.len() - ord - 1,
+    };
+    let tmp = indexes[ord];
+    indexes.copy_within(ord + 1..ord + 1 + pos, ord);
+    indexes[ord + pos] = tmp;
 }
 
 fn align_scorers(


### PR DESCRIPTION
There are 2 main updates.

----

1. We use extra (idx, docid) vector to store the order of blockwand scorers and cache current docid.

Reason:
- Each blockwand scorer object has big size (144B), we should avoid swaping them.
- `scorer.posting.docid()` isn't cheap due to branch prediction.

----

2. Optimize swaping of `restore_ordering`.

Previously, it will swap for each comparing like bubble sort. Now, it will first find the correct position, and then execute memmove once.

----

### bench on arguana top10:
- before: 19.2153s (73.17/s)
- apply optimization 1: 11.2671s (124.79/s) 70.5% up
- apply all optimizations: 10.9854s (127.99/s) 74.9% up

