### PR TITLE
feat: cast int[] to bm25vector

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ In contrast, Vectorchord-bm25 focuses exclusively on BM25 ranking within Postgre
 
 ### Data Types
 
-- `bm25vector`: A vector type for storing BM25 tokenized text.
+- `bm25vector`: A specialized vector type for storing BM25 tokenized text. Structured as a sparse vector, it stores token IDs and their corresponding frequencies. For example, `{1:2, 2:1}` indicates that token ID 1 appears twice and token ID 2 appears once in the document.
 - `bm25query`: A query type for BM25 ranking.
 
 ### Functions
@@ -184,6 +184,10 @@ In contrast, Vectorchord-bm25 focuses exclusively on BM25 ranking within Postgre
 - `tokenize(content text, tokenizer_name text) RETURNS bm25vector`: Tokenize the content text into a BM25 vector. 
 - `to_bm25query(index_name regclass, query text, tokenizer_name text) RETURNS bm25query`: Convert the input text into a BM25 query.
 - `bm25vector <&> bm25query RETURNS float4`: Calculate the **negative** BM25 score between the BM25 vector and query.
+
+### Casts
+
+- `int[]::bm25vector (implicit)`: Cast an integer array to a BM25 vector. The integer array represents token IDs, and the cast aggregates duplicates into frequencies, ignoring token order. For example, `{1, 2, 1}` will be cast to `{1:2, 2:1}` (token ID 1 appears twice, token ID 2 appears once).
 
 ### GUCs
 

--- a/src/datatype/cast.rs
+++ b/src/datatype/cast.rs
@@ -1,0 +1,10 @@
+use crate::datatype::Bm25VectorOutput;
+
+#[pgrx::pg_extern(immutable, strict, parallel_safe)]
+fn _vchord_bm25_cast_array_to_bm25vector(
+    array: pgrx::datum::Array<i32>,
+    _typmod: i32,
+    _explicit: bool,
+) -> Bm25VectorOutput {
+    Bm25VectorOutput::from_ids(array.iter().map(|x| x.unwrap().try_into().unwrap()))
+}

--- a/src/datatype/memory_bm25vector.rs
+++ b/src/datatype/memory_bm25vector.rs
@@ -107,10 +107,10 @@ impl Bm25VectorOutput {
         }
     }
 
-    pub fn from_ids(ids: &[u32]) -> Self {
+    pub fn from_ids(ids: impl Iterator<Item = u32>) -> Self {
         let mut map: BTreeMap<u32, u32> = BTreeMap::new();
         for term_id in ids {
-            *map.entry(*term_id).or_insert(0) += 1;
+            *map.entry(term_id).or_insert(0) += 1;
         }
         let mut doc_len: u32 = 0;
         let mut indexes = Vec::with_capacity(map.len());

--- a/src/datatype/mod.rs
+++ b/src/datatype/mod.rs
@@ -1,6 +1,7 @@
 mod binary_bm25vector;
 mod bm25vector;
 mod bytea;
+mod cast;
 mod functions;
 mod memory_bm25vector;
 mod text_bm25vector;

--- a/src/sql/finalize.sql
+++ b/src/sql/finalize.sql
@@ -8,6 +8,9 @@ CREATE TYPE bm25vector (
     ALIGNMENT = double
 );
 
+CREATE CAST (int[] AS bm25vector)
+    WITH FUNCTION _vchord_bm25_cast_array_to_bm25vector(int[], integer, boolean) AS IMPLICIT;
+
 CREATE TYPE bm25query AS (
     index_oid regclass,
     query_vector bm25vector

--- a/src/token.rs
+++ b/src/token.rs
@@ -386,7 +386,7 @@ pub fn tokenize(content: &str, tokenizer_name: &str) -> Bm25VectorOutput {
         "Tocken" => TOCKENIZER.encode(content),
         _ => custom_tokenize(content, tokenizer_name),
     };
-    Bm25VectorOutput::from_ids(&term_ids)
+    Bm25VectorOutput::from_ids(term_ids.iter().copied())
 }
 
 fn custom_tokenize(text: &str, tokenizer_name: &str) -> Vec<u32> {

--- a/tests/sqllogictest/cast.slt
+++ b/tests/sqllogictest/cast.slt
@@ -1,0 +1,4 @@
+query T
+SELECT '{1, 2, 1}'::int[]::bm25vector;
+----
+{1:2, 2:1}


### PR DESCRIPTION
This is used to decouple the tokenization process.