### PR TITLE
chore: bump sccache to 0.0.8

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Set up Environment
         run: ./tools/setup.sh
       - name: Set up Sccache
-        uses: mozilla-actions/sccache-action@v0.0.7
+        uses: mozilla-actions/sccache-action@v0.0.8
       - name: Clippy
         run: cargo clippy --features pg${{ matrix.version }}
       - name: Unit Test


### PR DESCRIPTION
https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/