### PR TITLE
feat: support prefilter

### DIFF
--- a/src/datatype/functions.rs
+++ b/src/datatype/functions.rs
@@ -41,5 +41,5 @@ pub fn search_bm25query(
         query_vector,
     );
 
-    scores * -1.0
+    -scores
 }

--- a/src/datatype/memory_bm25vector.rs
+++ b/src/datatype/memory_bm25vector.rs
@@ -44,7 +44,7 @@ impl Bm25VectorHeader {
             std::slice::from_raw_parts(ptr, len)
         }
     }
-    pub fn borrow(&self) -> Bm25VectorBorrowed {
+    pub fn borrow(&self) -> Bm25VectorBorrowed<'_> {
         unsafe { Bm25VectorBorrowed::new_unchecked(self.doc_len, self.indexes(), self.values()) }
     }
     pub fn to_bytes(&self) -> &[u8] {

--- a/src/datatype/text_bm25vector.rs
+++ b/src/datatype/text_bm25vector.rs
@@ -151,10 +151,10 @@ fn _bm25catalog_bm25vector_out(vector: Bm25VectorInput<'_>) -> CString {
     for (&index, &value) in vector.indexes().iter().zip(vector.values().iter()) {
         match need_splitter {
             false => {
-                write!(buffer, "{}:{}", index, value).unwrap();
+                write!(buffer, "{index}:{value}").unwrap();
                 need_splitter = true;
             }
-            true => write!(buffer, ", {}:{}", index, value).unwrap(),
+            true => write!(buffer, ", {index}:{value}").unwrap(),
         }
     }
     buffer.push('}');

--- a/src/guc.rs
+++ b/src/guc.rs
@@ -3,6 +3,7 @@ use pgrx::{GucContext, GucFlags, GucRegistry, GucSetting};
 pub static BM25_LIMIT: GucSetting<i32> = GucSetting::<i32>::new(100);
 pub static ENABLE_INDEX: GucSetting<bool> = GucSetting::<bool>::new(true);
 pub static SEGMENT_GROWING_MAX_PAGE_SIZE: GucSetting<i32> = GucSetting::<i32>::new(4096);
+pub static ENABLE_PREFILTER: GucSetting<bool> = GucSetting::<bool>::new(true);
 
 pub fn init() {
     GucRegistry::define_int_guc(
@@ -30,6 +31,14 @@ pub fn init() {
         &SEGMENT_GROWING_MAX_PAGE_SIZE,
         1,
         1_000_000,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+    GucRegistry::define_bool_guc(
+        "bm25_catalog.enable_prefilter",
+        "Whether to enable the prefilter",
+        "Whether to enable the prefilter for bm25 queries. If enabled, the prefilter will be used to filter out documents that do not match the query before scoring.",
+        &ENABLE_PREFILTER,
         GucContext::Userset,
         GucFlags::default(),
     );

--- a/src/index/hook.rs
+++ b/src/index/hook.rs
@@ -1,0 +1,87 @@
+#[pgrx::pg_guard]
+unsafe extern "C-unwind" fn rewrite_plan_state(
+    node: *mut pgrx::pg_sys::PlanState,
+    context: *mut core::ffi::c_void,
+) -> bool {
+    unsafe fn dirty_check_vchord_bm25(
+        index_relation: *mut pgrx::pg_sys::RelationData,
+    ) -> Option<bool> {
+        type FnPtr = unsafe extern "C-unwind" fn(
+            *mut pgrx::pg_sys::RelationData,
+            i32,
+            i32,
+        ) -> *mut pgrx::pg_sys::IndexScanDescData;
+        unsafe {
+            let index_relation = index_relation.as_ref()?;
+            let indam = index_relation.rd_indam.as_ref()?;
+            let ambeginscan = indam.ambeginscan.as_ref()?;
+            Some(core::ptr::fn_addr_eq::<FnPtr, FnPtr>(
+                *ambeginscan,
+                crate::index::scan::ambeginscan,
+            ))
+        }
+    }
+
+    unsafe {
+        if (*node).type_ == pgrx::pg_sys::NodeTag::T_IndexScanState {
+            let node = node as *mut pgrx::pg_sys::IndexScanState;
+            let index_relation = (*node).iss_RelationDesc;
+            if (*node).iss_ScanDesc.is_null()
+                && dirty_check_vchord_bm25(index_relation) == Some(true)
+            {
+                use crate::index::scan::Scanner;
+
+                (*node).iss_ScanDesc = pgrx::pg_sys::index_beginscan(
+                    (*node).ss.ss_currentRelation,
+                    (*node).iss_RelationDesc,
+                    (*(*node).ss.ps.state).es_snapshot,
+                    // #[cfg(feature = "pg18")]
+                    // std::ptr::null_mut(),
+                    (*node).iss_NumScanKeys,
+                    (*node).iss_NumOrderByKeys,
+                );
+
+                let scanner = &mut *((*(*node).iss_ScanDesc).opaque as *mut Scanner);
+                scanner.set_node(node);
+
+                if (*node).iss_NumRuntimeKeys == 0 || (*node).iss_RuntimeKeysReady {
+                    pgrx::pg_sys::index_rescan(
+                        (*node).iss_ScanDesc,
+                        (*node).iss_ScanKeys,
+                        (*node).iss_NumScanKeys,
+                        (*node).iss_OrderByKeys,
+                        (*node).iss_NumOrderByKeys,
+                    );
+                }
+            }
+        }
+        pgrx::pg_sys::planstate_tree_walker(node, Some(rewrite_plan_state), context)
+    }
+}
+
+static mut PREV_EXECUTOR_START: pgrx::pg_sys::ExecutorStart_hook_type = None;
+
+#[pgrx::pg_guard]
+unsafe extern "C-unwind" fn executor_start(
+    query_desc: *mut pgrx::pg_sys::QueryDesc,
+    eflags: core::ffi::c_int,
+) {
+    unsafe {
+        use core::ptr::null_mut;
+        use pgrx::pg_sys::submodules::ffi::pg_guard_ffi_boundary;
+        if let Some(prev_executor_start) = PREV_EXECUTOR_START {
+            #[allow(ffi_unwind_calls, reason = "protected by pg_guard_ffi_boundary")]
+            pg_guard_ffi_boundary(|| prev_executor_start(query_desc, eflags))
+        } else {
+            pgrx::pg_sys::standard_ExecutorStart(query_desc, eflags)
+        }
+        pg_guard_ffi_boundary(|| rewrite_plan_state((*query_desc).planstate, null_mut()));
+    }
+}
+
+pub fn init() {
+    unsafe {
+        PREV_EXECUTOR_START = pgrx::pg_sys::ExecutorStart_hook;
+        pgrx::pg_sys::ExecutorStart_hook = Some(executor_start);
+    }
+}

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -1,5 +1,6 @@
 mod am;
 mod build;
+mod hook;
 mod insert;
 mod options;
 mod scan;
@@ -7,4 +8,5 @@ mod vacuum;
 
 pub fn init() {
     options::init();
+    hook::init();
 }

--- a/src/segment/field_norm.rs
+++ b/src/segment/field_norm.rs
@@ -19,7 +19,7 @@ impl FieldNormWriter {
         pager.finalize()
     }
 
-    pub fn to_memory_reader(&self) -> FieldNormMemoryReader {
+    pub fn to_memory_reader(&self) -> FieldNormMemoryReader<'_> {
         FieldNormMemoryReader(&self.buffer)
     }
 }

--- a/tests/sqllogictest/prefilter.slt
+++ b/tests/sqllogictest/prefilter.slt
@@ -1,0 +1,71 @@
+statement ok
+SET bm25_catalog.bm25_limit=3;
+
+statement ok
+SET enable_seqscan=off;
+
+statement ok
+CREATE TABLE documents (
+    id SERIAL PRIMARY KEY,
+    passage TEXT,
+    embedding bm25vector,
+    condition BOOLEAN DEFAULT FALSE
+);
+
+statement ok
+INSERT INTO documents (passage) VALUES 
+('PostgreSQL is a powerful, open-source object-relational database system. It has over 15 years of active development.'),
+('Full-text search is a technique for searching in plain-text documents or textual database fields. PostgreSQL supports this with tsvector.'),
+('BM25 is a ranking function used by search engines to estimate the relevance of documents to a given search query.'),
+('PostgreSQL provides many advanced features like full-text search, window functions, and more.'),
+('Search and ranking in databases are important in building effective information retrieval systems.'),
+('The BM25 ranking algorithm is derived from the probabilistic retrieval framework.'),
+('Full-text search indexes documents to allow fast text queries. PostgreSQL supports this through its GIN and GiST indexes.'),
+('The PostgreSQL community is active and regularly improves the database system.'),
+('Relational databases such as PostgreSQL can handle both structured and unstructured data.'),
+('Effective search ranking algorithms, such as BM25, improve search results by understanding relevance.');
+
+statement ok
+SELECT create_tokenizer('tokenizer_bert', $$
+model = "bert_base_uncased"
+$$);
+
+statement ok
+UPDATE documents SET embedding = tokenize(passage, 'tokenizer_bert');
+
+statement ok
+CREATE INDEX documents_embedding_bm25 ON documents USING bm25 (embedding bm25_ops);
+
+statement ok
+UPDATE documents SET condition = True WHERE id % 2 = 0;
+
+query I
+WITH results AS (
+SELECT id, passage, embedding <&> to_bm25query('documents_embedding_bm25', tokenize('Post', 'tokenizer_bert')) AS rank
+FROM documents
+WHERE condition = TRUE
+ORDER BY rank
+LIMIT 10)
+SELECT COUNT(1) FROM results;
+----
+3
+
+statement ok
+SET bm25_catalog.enable_prefilter=off;
+
+query I
+WITH results AS (
+SELECT id, passage, embedding <&> to_bm25query('documents_embedding_bm25', tokenize('Post', 'tokenizer_bert')) AS rank
+FROM documents
+WHERE condition = TRUE
+ORDER BY rank
+LIMIT 10)
+SELECT COUNT(1) FROM results;
+----
+2
+
+statement ok
+DROP TABLE documents;
+
+statement ok
+SELECT drop_tokenizer('tokenizer_bert');


### PR DESCRIPTION
close #27

Add a new guc `bm25_catalog.enable_prefilter`. It will pushdown the where clause to index process. And index will check it before calculating bm25 score.

- `bm25_catalog.enable_prefilter` is **default true**.
- You can see `tests/sqllogictest/prefilter.slt` as an example.