### PR TITLE
Fix misleading order in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Create the index on the bm25vector column so that we can collect the global docu
 CREATE INDEX documents_embedding_bm25 ON documents USING bm25 (embedding bm25_ops);
 ```
 
-Now we can calculate the BM25 score between the query and the vectors. Note that the bm25 score is negative, which means the higher the score, the more relevant the document is. We intentionally make it negative so that you can use the default order by to get the most relevant documents first.
+Now we can calculate the BM25 score between the query and the vectors. Note that the BM25 score is negative, which means the more negative the score, the more relevant the document is. We intentionally make it negative so that you can use the default order by to get the most relevant documents first.
 
 ```sql
 -- to_bm25query(index_name, query, tokenizer_name)


### PR DESCRIPTION
The BM25 score is in range $(-\infty, 0]$, where more negative scores indicate more relevant documents. However, the readme says higher scores are more relevant. A score near 0 is higher than a more negative score, so this is wrong. It cost us quite some time and caused a lot of confusion to figure this out.